### PR TITLE
fix: create issue when none of the existing ones match

### DIFF
--- a/controllers/githubissue_controller_test.go
+++ b/controllers/githubissue_controller_test.go
@@ -95,7 +95,9 @@ var _ = Describe("GithubissueController", func() {
 					RepositoryURL: "https://github.com/clobrano/githubissues-operator",
 				}
 
-				mgc.EXPECT().GetTickets(underTest.Spec.Repo).Return([]gclient.GithubTicket{}, nil)
+				mgc.EXPECT().GetTickets(underTest.Spec.Repo).Return([]gclient.GithubTicket{
+					{Title: "Title different than expected"},
+				}, nil)
 				mgc.EXPECT().CreateTicket(want).Return(nil)
 
 				r := &GithubIssueReconciler{myClient, sch, mgc}


### PR DESCRIPTION
Currently, the CR only creates an issue when there is no issue in the repository.

This commit ensure that a new ticket is created if not other ticket with the same name already exists

Signed-off-by: Carlo Lobrano <c.lobrano@gmail.com>