### PR TITLE
Use more stable handle to track a github issue

### DIFF
--- a/api/v1alpha1/githubissue_types.go
+++ b/api/v1alpha1/githubissue_types.go
@@ -40,6 +40,10 @@ type GithubIssueSpec struct {
 // GithubIssueStatus defines the observed state of GithubIssue
 type GithubIssueStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+
+	// TrackedIssueId is the linked ticket number
+	// +kubebuilder:default:=0
+	TrackedIssueId int64 `json:"tracked_issue_id"`
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/training.redhat.com_githubissues.yaml
+++ b/config/crd/bases/training.redhat.com_githubissues.yaml
@@ -121,6 +121,13 @@ spec:
                   - type
                   type: object
                 type: array
+              tracked_issue_id:
+                default: 0
+                description: TrackedIssueId is the linked ticket number
+                format: int64
+                type: integer
+            required:
+            - tracked_issue_id
             type: object
         type: object
     served: true

--- a/controllers/githubissue_controller.go
+++ b/controllers/githubissue_controller.go
@@ -183,7 +183,8 @@ func (r *GithubIssueReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		})
 	}
 
-	if target.Body != gi.Spec.Description {
+	if target.Title != gi.Spec.Title || target.Body != gi.Spec.Description {
+		target.Title = gi.Spec.Title
 		target.Body = gi.Spec.Description
 		err = r.RepoClient.UpdateTicket(*target)
 		if err != nil {

--- a/controllers/githubissue_controller.go
+++ b/controllers/githubissue_controller.go
@@ -97,18 +97,10 @@ func (r *GithubIssueReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 	}()
 
-	tickets, err := r.RepoClient.GetTickets(gi.Spec.Repo)
+	target, err := r.getMatchingTarget(gi.Status.TrackedIssueId, gi.Spec.Repo, gi.Spec.Title)
 	if err != nil {
-		l.Error(err, "failed to get tickets", "Repo URL", gi.Spec.Repo)
+		l.Error(err, "could not get matching ticket", "Repo URL", gi.Spec.Repo)
 		return ctrl.Result{}, err
-	}
-
-	var target *gclient.GithubTicket
-	for _, t := range tickets {
-		if t.Title == gi.Spec.Title {
-			target = &t
-			break
-		}
 	}
 
 	if isGithubIssueMarkedToBeDeleted {
@@ -140,7 +132,22 @@ func (r *GithubIssueReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
-		return ctrl.Result{RequeueAfter: time.Minute}, nil
+
+		// immediately get the newly created ticket for linkage with Status.Number
+		target, err = r.getMatchingTarget(gi.Status.TrackedIssueId, gi.Spec.Repo, gi.Spec.Title)
+		if err != nil {
+			l.Error(err, "could not get matching ticket", "Repo URL", gi.Spec.Repo)
+			return ctrl.Result{}, err
+		}
+	}
+
+	if gi.Status.TrackedIssueId == 0 {
+		gi.Status.TrackedIssueId = target.Number
+		err := r.Client.Status().Update(ctx, gi)
+		if err != nil {
+			l.Error(err, "could not update Status.Number", "Target", target)
+			return ctrl.Result{}, err
+		}
 	}
 
 	if target.State == "open" {
@@ -193,4 +200,23 @@ func (r *GithubIssueReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&trainingv1alpha1.GithubIssue{}).
 		Complete(r)
+}
+
+func (r *GithubIssueReconciler) getMatchingTarget(issueId int64, url, title string) (*gclient.GithubTicket, error) {
+	tickets, err := r.RepoClient.GetTickets(url)
+	if err != nil {
+		return nil, err
+	}
+
+	var target *gclient.GithubTicket
+	for _, t := range tickets {
+		if issueId != 0 && issueId == t.Number {
+			target = &t
+			break
+		} else if title == t.Title {
+			target = &t
+			break
+		}
+	}
+	return target, nil
 }

--- a/controllers/githubissue_controller_test.go
+++ b/controllers/githubissue_controller_test.go
@@ -210,7 +210,9 @@ var _ = Describe("GithubissueController", func() {
 
 				mgc.EXPECT().GetTickets(underTest.Spec.Repo).Return([]gclient.GithubTicket{currentTicketWasChanged}, nil)
 				mgc.EXPECT().IssueHasPR(currentTicketWasChanged)
-				// Do not expect update, since only the title was changed
+				// Expecting the ticket's title to be reverted back to Spec
+				currentTicketWasChanged.Title = expectedIssueTitle
+				mgc.EXPECT().UpdateTicket(currentTicketWasChanged).Return(nil)
 				r = &GithubIssueReconciler{myClient, sch, mgc}
 				_, err = r.Reconcile(context.TODO(), req)
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Use the github issue's number as handle for future management of the ticket.

Once the operator recognize a matching ticket already exists, or create a new one, it "links" such ticket saving its number in resource's Status. Any future management of the ticket is managed via such number, so that the operator is able to recognize it even if the title is manually changed in Github.

To keep resource's Spec consistency, also the Title is now enforced, as well as the description.